### PR TITLE
feat:  Eslint config init, based on airbnb-base

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,7 @@
+!.eslintrc.js
+!.prettierrc.js
+
+node_modules/
+.DS_Store
+yarn.lock
+yarn-error.log

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  root: true,
+  extends: ['./typescript.js'],
+  rules: {
+    '@typescript-eslint/no-var-requires': 'off',
+  },
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.DS_Store
+
+package-lock.json
+yarn.lock
+yarn-error.log

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+node_modules/
+.DS_Store
+yarn.lock
+yarn-error.log
+
+*ignore

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,39 @@
+module.exports = {
+  // 一行最多 120 字符
+  printWidth: 120,
+  // 使用 2 个空格缩进
+  tabWidth: 2,
+  // 不使用缩进符，而使用空格
+  useTabs: false,
+  // 行尾需要有分号
+  semi: true,
+  // 使用单引号
+  singleQuote: true,
+  // 对象的 key 仅在必要时用引号
+  quoteProps: 'as-needed',
+  // jsx 不使用单引号，而使用双引号
+  jsxSingleQuote: false,
+  // 末尾需要有逗号
+  trailingComma: 'all',
+  // 大括号内的首尾需要空格
+  bracketSpacing: true,
+  // jsx 标签的反尖括号需要换行
+  jsxBracketSameLine: false,
+  // 箭头函数，只有一个参数的时候，也需要括号
+  arrowParens: 'always',
+  // 每个文件格式化的范围是文件的全部内容
+  rangeStart: 0,
+  rangeEnd: Infinity,
+  // 不需要写文件开头的 @prettier
+  requirePragma: false,
+  // 不需要自动在文件开头插入 @prettier
+  insertPragma: false,
+  // 使用默认的折行标准
+  proseWrap: 'preserve',
+  // 根据显示样式决定 html 要不要折行
+  htmlWhitespaceSensitivity: 'css',
+  // vue 文件中的 script 和 style 内不用缩进
+  vueIndentScriptAndStyle: false,
+  // 换行符使用 lf
+  endOfLine: 'lf',
+};

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,17 @@
+{
+  "files.eol": "\n",
+  "editor.tabSize": 2,
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "vue",
+    "typescript",
+    "typescriptreact"
+  ],
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ ESLint config for TDesign
 ## Base Usage
 ### Installation
 ```sh
-npm i eslint eslint-config-airbnb-base eslint-plugin-tdesign --save-dev
+npm i eslint @typescript-eslint/parser eslint-plugin-import eslint-config-tdesign --save-dev
 ```
 ### Use
 ```json
@@ -24,14 +24,13 @@ npm i eslint eslint-config-airbnb-base eslint-plugin-tdesign --save-dev
 ## Miniprogram Usage
 ### Installation
 ```sh
-npm i eslint eslint-config-airbnb-base eslint-config-prettier eslint-plugin-import eslint-plugin-tdesign --save-dev
+npm i eslint @typescript-eslint/parser eslint-plugin-import eslint-config-prettier eslint-plugin-prettier eslint-config-tdesign --save-dev
 ```
 ### Use
 ```json
 // .eslintrc.js
 {
 	"extends": [
-		"tdesign",
 		"tdesign/miniprogram"
 	]
 }
@@ -40,7 +39,7 @@ npm i eslint eslint-config-airbnb-base eslint-config-prettier eslint-plugin-impo
 ## TypeScript Usage
 ### Installation
 ```sh
-npm install eslint typescript eslint-config-airbnb-base @typescript-eslint/parser @typescript-eslint/eslint-plugin eslint-plugin-tdesign --save-dev
+npm install eslint typescript @typescript-eslint/parser eslint-plugin-import @typescript-eslint/eslint-plugin eslint-config-tdesign --save-dev
 ```
 ### Use
 ```json
@@ -56,14 +55,13 @@ npm install eslint typescript eslint-config-airbnb-base @typescript-eslint/parse
 ## Vue Usage
 ### Installation
 ```sh
-npm i eslint eslint-config-airbnb-base eslint-config-prettier vue-eslint-parser eslint-plugin-vue @vue/eslint-config-typescript eslint-plugin-tdesign --save-dev
+npm i eslint vue-eslint-parser eslint-plugin-import eslint-plugin-vue @typescript-eslint/eslint-plugin eslint-config-tdesign --save-dev
 ```
 ### Use
 ```json
 // .eslintrc.js
 {
 	"extends": [
-		"tdesign",
 		"tdesign/vue"
 	]
 }
@@ -71,14 +69,13 @@ npm i eslint eslint-config-airbnb-base eslint-config-prettier vue-eslint-parser 
 ## Vue-next Usage
 ### Installation
 ```sh
-npm i eslint eslint-config-airbnb-base eslint-config-prettier vue-eslint-parser eslint-plugin-vue  eslint-plugin-tdesign --save-dev
+npm i eslint vue-eslint-parser eslint-plugin-import eslint-config-prettier eslint-plugin-prettier eslint-plugin-vue eslint-config-tdesign --save-dev
 ```
 ### Use
 ```json
 // .eslintrc.js
 {
 	"extends": [
-		"tdesign",
 		"tdesign/vue-next"
 	]
 }
@@ -87,14 +84,13 @@ npm i eslint eslint-config-airbnb-base eslint-config-prettier vue-eslint-parser 
 ## React Usage
 ### Installation
 ```sh
-npm i eslint prettier eslint-config-airbnb-base eslint-config-prettier eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-lodash eslint-plugin-tdesign --save-dev
+npm i eslint @typescript-eslint/parser eslint-plugin-import eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-lodash eslint-config-tdesign --save-dev
 ```
 ### Use
 ```json
 // .eslintrc.js
 {
 	"extends": [
-		"tdesign",
 		"tdesign/react"
 	]
 }
@@ -103,14 +99,13 @@ npm i eslint prettier eslint-config-airbnb-base eslint-config-prettier eslint-pl
 ## TypeScript React Usage
 ### Installation
 ```sh
-npm install eslint typescript eslint-config-airbnb-base eslint-config-prettier  @typescript-eslint/parser @typescript-eslint/eslint-plugin eslint-plugin-react eslint-plugin-tdesign --save-dev
+npm install eslint typescript @typescript-eslint/parser eslint-plugin-import @typescript-eslint/eslint-plugin eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-lodash eslint-config-tdesign --save-dev
 ```
 ### Use
 ```json
 // .eslintrc.js
 {
 	"extends": [
-		"tdesign",
 		"tdesign/typescript",
 		"tdesign/react",
 	]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,118 @@
 # eslint-config-tdesign
 ESLint config for TDesign
+
+>Tips: 规则有优先级，注意 `extends` 中的顺序
+>1. 如果 `extends` 配置的是一个数组，那么最终会将所有规则项进行合并，出现冲突的时候，后面的会覆盖前面的。
+>2. 通过 `rules` 单独配置的规则,优先级高于 `extends` 。
+
+
+## Base Usage
+### Installation
+```sh
+npm i eslint eslint-config-airbnb-base eslint-plugin-tdesign --save-dev
+```
+### Use
+```json
+// .eslintrc.js
+{
+	"extends": [
+		"tdesign"
+	]
+}
+```
+
+## Miniprogram Usage
+### Installation
+```sh
+npm i eslint eslint-config-airbnb-base eslint-config-prettier eslint-plugin-import eslint-plugin-tdesign --save-dev
+```
+### Use
+```json
+// .eslintrc.js
+{
+	"extends": [
+		"tdesign",
+		"tdesign/miniprogram"
+	]
+}
+```
+
+## TypeScript Usage
+### Installation
+```sh
+npm install eslint typescript eslint-config-airbnb-base @typescript-eslint/parser @typescript-eslint/eslint-plugin eslint-plugin-tdesign --save-dev
+```
+### Use
+```json
+// .eslintrc.js
+{
+	"extends": [
+		"tdesign",
+		"tdesign/typescript"
+	]
+}
+```
+
+## Vue Usage
+### Installation
+```sh
+npm i eslint eslint-config-airbnb-base eslint-config-prettier vue-eslint-parser eslint-plugin-vue @vue/eslint-config-typescript eslint-plugin-tdesign --save-dev
+```
+### Use
+```json
+// .eslintrc.js
+{
+	"extends": [
+		"tdesign",
+		"tdesign/vue"
+	]
+}
+```
+## Vue-next Usage
+### Installation
+```sh
+npm i eslint eslint-config-airbnb-base eslint-config-prettier vue-eslint-parser eslint-plugin-vue  eslint-plugin-tdesign --save-dev
+```
+### Use
+```json
+// .eslintrc.js
+{
+	"extends": [
+		"tdesign",
+		"tdesign/vue-next"
+	]
+}
+```
+
+## React Usage
+### Installation
+```sh
+npm i eslint prettier eslint-config-airbnb-base eslint-config-prettier eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-lodash eslint-plugin-tdesign --save-dev
+```
+### Use
+```json
+// .eslintrc.js
+{
+	"extends": [
+		"tdesign",
+		"tdesign/react"
+	]
+}
+```
+
+## TypeScript React Usage
+### Installation
+```sh
+npm install eslint typescript eslint-config-airbnb-base eslint-config-prettier  @typescript-eslint/parser @typescript-eslint/eslint-plugin eslint-plugin-react eslint-plugin-tdesign --save-dev
+```
+### Use
+```json
+// .eslintrc.js
+{
+	"extends": [
+		"tdesign",
+		"tdesign/typescript",
+		"tdesign/react",
+	]
+}
+```

--- a/base.js
+++ b/base.js
@@ -1,0 +1,24 @@
+const javascriptRule = require('./rules/javascript');
+
+module.exports = {
+  root: true,
+  extends: ['eslint-config-airbnb-base'],
+  parserOptions: {
+    ecmaVersion: 2019,
+    sourceType: 'module',
+    allowImportExportEverywhere: true,
+    ecmaFeatures: {
+      impliedStrict: true,
+      jsx: true,
+    },
+  },
+  env: {
+    browser: true,
+    node: true,
+    es6: true,
+    jest: true,
+  },
+  rules: {
+    ...javascriptRule,
+  },
+};

--- a/base.js
+++ b/base.js
@@ -4,6 +4,7 @@ module.exports = {
   root: true,
   extends: ['eslint-config-airbnb-base'],
   parserOptions: {
+    parser: '@typescript-eslint/parser',
     ecmaVersion: 2019,
     sourceType: 'module',
     allowImportExportEverywhere: true,

--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['./base.js'],
+};

--- a/miniprogram.js
+++ b/miniprogram.js
@@ -1,0 +1,31 @@
+module.exports = {
+  extends: ['plugin:prettier/recommended'],
+  plugins: ['import'],
+  globals: {
+    require: true,
+    Page: true,
+    wx: true,
+    App: true,
+    getApp: true,
+    getCurrentPages: true,
+    Component: true,
+    getRegExp: true,
+    Behavior: true,
+  },
+  rules: {},
+  overrides: [
+    {
+      files: ['script/**'],
+      rules: {
+        // node 环境下支持 require
+        '@typescript-eslint/no-require-imports': 'off',
+      },
+    },
+    {
+      files: ['example/**'],
+      rules: {
+        'no-console': 0,
+      },
+    },
+  ],
+};

--- a/miniprogram.js
+++ b/miniprogram.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ['plugin:prettier/recommended'],
+  extends: ['./base', 'plugin:prettier/recommended'],
   plugins: ['import'],
   globals: {
     require: true,

--- a/package.json
+++ b/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "eslint-config-tdesign",
+  "version": "0.0.0",
+  "description": "ESLint config for TDesign",
+  "keywords": [
+    "eslint",
+    "eslintplugin",
+    "eslint-plugin",
+    "eslintconfig",
+    "tdesign",
+    "vue",
+    "react",
+    "typescript"
+  ],
+  "author": "none",
+  "main": "index.js",
+  "scripts": {
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^5.21.0",
+    "@typescript-eslint/parser": "^5.21.0",
+    "@vue/eslint-config-typescript": "^10.0.0",
+    "eslint": "^7.0.0",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-eslint-plugin": "^4.1.0",
+    "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-lodash": "^7.4.0",
+    "eslint-plugin-prettier": "^4.0.0",
+    "eslint-plugin-react": "^7.29.4",
+    "eslint-plugin-react-hooks": "^4.5.0",
+    "eslint-plugin-vue": "^8.7.1",
+    "prettier": "^2.6.2",
+    "react": "^18.1.0",
+    "typescript": "^4.6.3",
+    "vue-eslint-parser": "^8.3.0"
+  },
+  "peerDependencies": {},
+  "license": "MIT"
+}

--- a/package.json
+++ b/package.json
@@ -1,19 +1,20 @@
 {
   "name": "eslint-config-tdesign",
-  "version": "0.0.0",
+  "version": "0.0.1",
+  "main": "index.js",
   "description": "ESLint config for TDesign",
   "keywords": [
     "eslint",
-    "eslintplugin",
-    "eslint-plugin",
     "eslintconfig",
+    "config",
     "tdesign",
     "vue",
     "react",
-    "typescript"
+    "typescript",
+    "miniprogram"
   ],
-  "author": "none",
-  "main": "index.js",
+  "author": "tdesign",
+  "license": "MIT",
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
@@ -38,6 +39,18 @@
     "typescript": "^4.6.3",
     "vue-eslint-parser": "^8.3.0"
   },
-  "peerDependencies": {},
-  "license": "MIT"
+  "peerDependencies": {
+    "eslint": "^7.0.0",
+    "@typescript-eslint/eslint-plugin": "^5.21.0",
+    "@typescript-eslint/parser": "^5.21.0",
+    "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-lodash": "^7.4.0",
+    "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-prettier": "^4.0.0",
+    "eslint-plugin-react": "^7.29.4",
+    "eslint-plugin-react-hooks": "^4.5.0",
+    "eslint-plugin-vue": "^8.7.1",
+    "vue-eslint-parser": "^8.3.0",
+    "typescript": "^4.6.3"
+  }
 }

--- a/react.js
+++ b/react.js
@@ -2,6 +2,7 @@ const reactRule = require('./rules/react');
 
 module.exports = {
   extends: [
+    './base',
     'prettier', // eslint-config-prettier 处理冲突
     'plugin:react/recommended',
     'plugin:import/typescript',

--- a/react.js
+++ b/react.js
@@ -1,0 +1,19 @@
+const reactRule = require('./rules/react');
+
+module.exports = {
+  extends: [
+    'prettier', // eslint-config-prettier 处理冲突
+    'plugin:react/recommended',
+    'plugin:import/typescript',
+  ],
+  plugins: ['react-hooks', 'lodash'],
+  settings: {
+    react: {
+      pragma: 'React',
+      version: 'detect',
+    },
+  },
+  rules: {
+    ...reactRule,
+  },
+};

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -1,0 +1,86 @@
+module.exports = {
+  // "off" 或 0 - 关闭规则
+  // "warn" 或 1 - 开启规则，使用警告级别的错误：warn (不会导致程序退出)
+  // "error" 或 2 - 开启规则，使用错误级别的错误：error (当被触发时，程序会退出)
+
+  // import config
+  'import/no-extraneous-dependencies': 'off',
+  'import/order': 'error',
+  'import/extensions': 'off',
+  'import/no-named-as-default': 'off',
+  'import/prefer-default-export': 'off',
+  'import/no-cycle': 'off', // TODO: turn on this rule later
+  'import/no-unresolved': 'off', // TODO: turn on this rule later
+  'import/no-relative-packages': 'off',
+  'import/export': 'off',
+  'import/no-dynamic-require': 'off',
+
+  // code style config
+  'max-len': 'off',
+  'no-shadow': 'off',
+  'no-throw-literal': 'off',
+  'no-unused-expressions': 'off',
+  'no-bitwise': 'off',
+  'no-useless-return': 'off',
+  'no-plusplus': 'off',
+  'no-continue': 'off',
+  'no-return-assign': 'off',
+  'no-restricted-syntax': 'off',
+  'no-restricted-globals': 'off',
+  'no-unneeded-ternary': 'off',
+  'eol-last': 'error', // codecc
+  'func-names': 'off',
+  'consistent-return': 'off',
+  'default-case': 'off',
+  camelcase: 'off',
+  'no-console': [
+    2,
+    {
+      allow: ['warn', 'error'],
+    },
+  ],
+  'no-param-reassign': 'off',
+  'no-underscore-dangle': 'off',
+  'no-unused-vars': 'off',
+  'guard-for-in': 'off',
+  'default-param-last': 'off',
+  'prefer-spread': 'off',
+  'no-new': 1,
+  'new-cap': 'off',
+  'no-confusing-arrow': 'off',
+  'func-style': 'off',
+  'prefer-default-export': 'off',
+  'no-useless-constructor': 'off',
+  treatUndefinedAsUnspecified: 'off',
+  'no-use-before-define': [
+    'off',
+    {
+      functions: false,
+      classes: false,
+    },
+  ],
+  'no-proto': 'off',
+  'global-require': 'off',
+  'no-constant-condition': [
+    'error',
+    {
+      checkLoops: false,
+    },
+  ],
+  'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'warn', // 非开发模式禁用debugger
+  'number-leading-zero': 'off',
+  'object-shorthand': 'off',
+  'class-methods-use-this': 'off',
+  'no-undef': 'off',
+  eqeqeq: [
+    'error',
+    'always',
+    {
+      null: 'ignore',
+    },
+  ],
+
+  'no-promise-executor-return': 'off',
+  'prefer-regex-literals': 'off',
+  'no-unsafe-optional-chaining': 'off',
+};

--- a/rules/react.js
+++ b/rules/react.js
@@ -1,0 +1,8 @@
+module.exports = {
+  'react-hooks/exhaustive-deps': 'warn',
+  'react-hooks/rules-of-hooks': 'error',
+  'react/display-name': 'off',
+  'react/prop-types': 'off',
+
+  'lodash/import-scope': [2, 'method'],
+};

--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -1,0 +1,34 @@
+module.exports = {
+  // typescript config
+  '@typescript-eslint/explicit-module-boundary-types': 'off',
+  '@typescript-eslint/ban-types': 'off',
+  '@typescript-eslint/explicit-function-return-type': 'off',
+  '@typescript-eslint/indent': ['off', 2],
+  '@typescript-eslint/ban-ts-comment': 'off',
+  '@typescript-eslint/camelcase': 'off',
+  '@typescript-eslint/no-explicit-any': 'off',
+  '@typescript-eslint/no-use-before-define': ['error', { functions: false }],
+  '@typescript-eslint/no-var-requires': 'off',
+  '@typescript-eslint/no-unused-vars': 'error', // codecc
+  '@typescript-eslint/no-require-imports': 'off',
+  '@typescript-eslint/prefer-for-of': 'off',
+  '@typescript-eslint/no-empty-function': 'off',
+  '@typescript-eslint/naming-convention': [
+    'error',
+    {
+      selector: 'interface',
+      format: ['PascalCase'],
+      custom: {
+        regex: '^I[A-Z]',
+        match: false,
+      },
+    },
+  ],
+
+  '@typescript-eslint/ban-ts-ignore': 'off',
+  '@typescript-eslint/semi': 'off',
+  '@typescript-eslint/explicit-member-accessibility': 'off',
+  '@typescript-eslint/prefer-as-const': 'off',
+  '@typescript-eslint/no-empty-interface': 'off', // TODO: turn on this rule later
+  '@typescript-eslint/no-extra-semi': 'off',
+};

--- a/rules/vue.js
+++ b/rules/vue.js
@@ -1,0 +1,6 @@
+module.exports = {
+  'vue/require-default-prop': 'off',
+  'vue/multi-word-component-names': 'off',
+  'vue/no-useless-template-attributes': 'off',
+  'vue/html-indent': 'off',
+};

--- a/typescript.js
+++ b/typescript.js
@@ -1,0 +1,10 @@
+const typescriptRule = require('./rules/typescript');
+
+module.exports = {
+  extends: ['plugin:@typescript-eslint/recommended'],
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
+  rules: {
+    ...typescriptRule,
+  },
+};

--- a/vue-next.js
+++ b/vue-next.js
@@ -1,0 +1,63 @@
+const vueRule = require('./rules/vue');
+
+module.exports = {
+  extends: ['plugin:vue/vue3-recommended', 'plugin:prettier/recommended'],
+  plugins: ['vue'],
+  parser: 'vue-eslint-parser',
+  parserOptions: {
+    parser: '@typescript-eslint/parser',
+    extraFileExtensions: ['.vue'],
+  },
+  globals: {
+    cy: 'readonly',
+    clipboardData: 'readonly',
+    PKG_VERSION: true,
+  },
+  settings: {
+    'import/extensions': ['.js', '.jsx', '.ts', '.tsx'],
+  },
+  rules: {
+    ...vueRule,
+    'no-console': 'off', // TODO: turn on this rule later
+    '@typescript-eslint/no-unused-vars': 'off', // TODO: turn on this rule later
+    '@typescript-eslint/no-use-before-define': 'off', // TODO: turn on this rule later
+  },
+  overrides: [
+    {
+      files: ['*.vue'],
+      rules: {
+        'vue/component-name-in-template-casing': [2, 'kebab-case'],
+        'vue/require-default-prop': 0,
+        'vue/multi-word-component-names': 0,
+        'vue/no-reserved-props': 0,
+      },
+    },
+    {
+      files: ['**/demos/*', 'script/**/*', 'script/*', '*.js', 'site/**/*', 'site/*'],
+      rules: {
+        'no-var-requires': 0,
+        'no-console': 0,
+        'no-unused-expressions': 0,
+        'no-alert': 0,
+      },
+    },
+    {
+      // enable the rule specifically for TypeScript files
+      files: ['*.ts', '*.tsx'],
+      rules: {
+        'prefer-spread': 0,
+        '@typescript-eslint/explicit-function-return-type': 0,
+      },
+    },
+    {
+      files: ['*.test.js'],
+      rules: {
+        'import/no-dynamic-require': 'off',
+        'global-require': 'off',
+      },
+    },
+    {
+      files: '*',
+    },
+  ],
+};

--- a/vue-next.js
+++ b/vue-next.js
@@ -1,11 +1,10 @@
 const vueRule = require('./rules/vue');
 
 module.exports = {
-  extends: ['plugin:vue/vue3-recommended', 'plugin:prettier/recommended'],
+  extends: ['./base', 'plugin:vue/vue3-recommended', 'plugin:prettier/recommended'],
   plugins: ['vue'],
   parser: 'vue-eslint-parser',
   parserOptions: {
-    parser: '@typescript-eslint/parser',
     extraFileExtensions: ['.vue'],
   },
   globals: {

--- a/vue.js
+++ b/vue.js
@@ -1,0 +1,57 @@
+const vueRule = require('./rules/vue');
+
+module.exports = {
+  extends: ['plugin:vue/essential', '@vue/typescript/recommended'],
+  parser: 'vue-eslint-parser',
+  plugins: ['vue'],
+  globals: {
+    cy: 'readonly',
+    __VERSION__: true,
+  },
+  settings: {
+    'import/resolver': {
+      node: {},
+    },
+    'import/extensions': ['.js', '.jsx', '.ts', '.tsx'],
+  },
+  rules: {
+    ...vueRule,
+    '@typescript-eslint/no-use-before-define': 'off', // TODO: turn on this rule later
+  },
+  overrides: [
+    {
+      files: ['*.vue'],
+      rules: {
+        indent: 2,
+        'vue/html-indent': [2, 2],
+        'vue/return-in-computed-property': 1,
+        'vue/order-in-components': 2,
+        'vue/component-name-in-template-casing': [2, 'kebab-case'],
+        'vue/require-default-prop': 0,
+      },
+    },
+    {
+      files: ['**/demos/*', 'script/**/*', 'script/*', '*.js', 'site/**/*', 'site/*'],
+      rules: {
+        'no-var-requires': 0,
+        'no-console': 0,
+        'no-unused-expressions': 0,
+        'no-alert': 0,
+      },
+    },
+    {
+      // enable the rule specifically for TypeScript files
+      files: ['*.js', '*.ts', '*.tsx'],
+      rules: {
+        'prefer-spread': 'off',
+
+        '@typescript-eslint/no-explicit-any': 0,
+        '@typescript-eslint/no-empty-function': 0,
+        '@typescript-eslint/ban-ts-comment': 0,
+        '@typescript-eslint/ban-types': 0,
+        '@typescript-eslint/explicit-function-return-type': 0,
+        '@typescript-eslint/type-annotation-spacing': 1,
+      },
+    },
+  ],
+};

--- a/vue.js
+++ b/vue.js
@@ -1,7 +1,7 @@
 const vueRule = require('./rules/vue');
 
 module.exports = {
-  extends: ['plugin:vue/essential', '@vue/typescript/recommended'],
+  extends: ['./base', 'plugin:vue/essential', '@vue/typescript/recommended'],
   parser: 'vue-eslint-parser',
   plugins: ['vue'],
   globals: {


### PR DESCRIPTION
- 抽离eslint时，取的是各个框架的eslint“并集”，规范相应有所增加，因此引用时会存在规则冲突，部分框架通过暂时关闭部分规则解决冲突问题，剩余冲突认为各框架均可相应执行，统一开发规范。
例no-console规则：`'no-console': [
    2,
    {
      allow: ['warn', 'error'],
    },
  ],`
- 规则有优先级，注意 `extends` 中的顺序。